### PR TITLE
Allow installing of the compatibility module without any other module (since most of them are available on Maven central)

### DIFF
--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -21,5 +21,11 @@
                 <module>compatibility-v4</module>
             </modules>
         </profile>
+        <profile>
+            <id>compat-only</id>
+            <modules>
+                <module>compatibility-v4</module>
+            </modules>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Adding a compat-only pfofile, to install only the compatibility module. Usage: mvn install -P !all,compat-only
