### PR TITLE
fix paths to google-apis

### DIFF
--- a/add-ons/google-apis-10/pom.xml
+++ b/add-ons/google-apis-10/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <jar.simpleVersion>10</jar.simpleVersion>
+        <addon.directory>addon_google_apis_google_inc_${jar.simpleVersion}</addon.directory>
     </properties>
 
     <build>

--- a/add-ons/google-apis-11/pom.xml
+++ b/add-ons/google-apis-11/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <jar.simpleVersion>11</jar.simpleVersion>
+        <addon.directory>addon_google_apis_google_inc_${jar.simpleVersion}</addon.directory>
     </properties>
 
     <build>

--- a/add-ons/google-apis-12/pom.xml
+++ b/add-ons/google-apis-12/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <jar.simpleVersion>12</jar.simpleVersion>
+        <addon.directory>addon_google_apis_google_inc_${jar.simpleVersion}</addon.directory>
     </properties>
 
     <build>

--- a/add-ons/google-apis-13/pom.xml
+++ b/add-ons/google-apis-13/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <jar.simpleVersion>13</jar.simpleVersion>
+        <addon.directory>addon_google_apis_google_inc_${jar.simpleVersion}</addon.directory>
     </properties>
 
     <build>

--- a/add-ons/google-apis-14/pom.xml
+++ b/add-ons/google-apis-14/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <jar.simpleVersion>14</jar.simpleVersion>
+        <addon.directory>addon-google_apis-google-${jar.simpleVersion}</addon.directory>
     </properties>
 
     <build>

--- a/add-ons/google-apis-15/pom.xml
+++ b/add-ons/google-apis-15/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <jar.simpleVersion>15</jar.simpleVersion>
+        <addon.directory>addon-google_apis-google-${jar.simpleVersion}</addon.directory>
     </properties>
 
     <build>

--- a/add-ons/google-apis-3/pom.xml
+++ b/add-ons/google-apis-3/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <jar.simpleVersion>3</jar.simpleVersion>
+        <addon.directory>addon-google_apis-google-${jar.simpleVersion}</addon.directory>
     </properties>
 
     <build>

--- a/add-ons/google-apis-4/pom.xml
+++ b/add-ons/google-apis-4/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <jar.simpleVersion>4</jar.simpleVersion>
+        <addon.directory>addon-google_apis-google-${jar.simpleVersion}</addon.directory>
     </properties>
 
     <build>

--- a/add-ons/google-apis-7/pom.xml
+++ b/add-ons/google-apis-7/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <jar.simpleVersion>7</jar.simpleVersion>
+        <addon.directory>addon-google_apis-google-${jar.simpleVersion}</addon.directory>
     </properties>
 
     <build>

--- a/add-ons/google-apis-8/pom.xml
+++ b/add-ons/google-apis-8/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <jar.simpleVersion>8</jar.simpleVersion>
+        <addon.directory>addon-google_apis-google-${jar.simpleVersion}</addon.directory>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <sdk.platforms.path>${android.sdk.path}/platforms</sdk.platforms.path>
         <sdk.addons.path>${android.sdk.path}/add-ons</sdk.addons.path>
         <sdk.extras.path>${android.sdk.path}/extras</sdk.extras.path>
-        <sdk.extras.compatibility.path>${sdk.extras.path}/android/support</sdk.extras.compatibility.path>
+        <sdk.extras.compatibility.path>${sdk.extras.path}/android/compatibility</sdk.extras.compatibility.path>
         <platform.android.groupid>android</platform.android.groupid>
         <platform.android.artifactid>android</platform.android.artifactid>
         <addon.googlemaps.groupid>com.google.android.maps</addon.googlemaps.groupid>


### PR DESCRIPTION
This patch fixes looking up for paths to various versions of google apis. Checked with latest SDK (Mac x86).
