### PR TITLE
Deploy phase had incorrect groupId set

### DIFF
--- a/extras/google-play-services/pom.xml
+++ b/extras/google-play-services/pom.xml
@@ -64,7 +64,7 @@
                             <goal>deploy-file</goal>
                         </goals>
                         <configuration>
-                            <groupId>${extras.admob.groupid}</groupId>
+                            <groupId>${extras.google.play.services.groupid}</groupId>
                             <artifactId>${extras.google.play.services.artifactId}</artifactId>
                             <packaging>jar</packaging>
                             <version>${jar.version}</version>


### PR DESCRIPTION
Sorry I found a copy/paste bug in the patch I submitted last week.
The groupId was set to admob in the deploy phase.
