### PR TITLE
Fixed Google Play Services install for version 2

### DIFF
--- a/extras/google-play-services/pom.xml
+++ b/extras/google-play-services/pom.xml
@@ -13,7 +13,7 @@
     </parent>
 
     <properties>
-        <jar.path>${sdk.extras.google.play.services.path}/libs/google-play-services.jar</jar.path>
+        <jar.path>${sdk.extras.google.play.services.path}/libproject/google-play-services_lib/libs/google-play-services.jar</jar.path>
         <extras.google.play.services.artifactId>google-play-services</extras.google.play.services.artifactId>
         <jar.version>${Pkg.Revision}</jar.version>
     </properties>


### PR DESCRIPTION
The correct path for the `google-play-services.jar` is `${ANDROID_HOME}/extras/google/google_play_services/libproject/google-play-services_lib/libs/google-play-services.jar`.
