### PR TITLE
fix wrong analytics sdk path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <sdk.addons.path>${android.sdk.path}/add-ons</sdk.addons.path>
         <sdk.extras.path>${android.sdk.path}/extras</sdk.extras.path>
         <sdk.extras.compatibility.path>${sdk.extras.path}/android/support</sdk.extras.compatibility.path>
-        <sdk.extras.analytics.path>${sdk.extras.path}/google/analytics_sdk</sdk.extras.analytics.path>
+        <sdk.extras.analytics.path>${sdk.extras.path}/google/analytics_sdk_v2</sdk.extras.analytics.path>
         <sdk.extras.admob.path>${sdk.extras.path}/google/admob_ads_sdk</sdk.extras.admob.path>
         <sdk.extras.gcm.path>${sdk.extras.path}/google/gcm</sdk.extras.gcm.path>
         <sdk.extras.google.play.services.path>${sdk.extras.path}/google/google_play_services</sdk.extras.google.play.services.path>


### PR DESCRIPTION
I just downloaded both all the sdk extras and the deployer. When running mvn install it always failed at the analytics sdk. For me the path was analytics_sdk_v2 and not analytics_sdk.
