### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -319,7 +319,7 @@ For the usb add on
 <dependency>
   <groupId>com.android.future</groupId>
   <artifactId>usb</artifactId>
-  <version>17_r1</version>
+  <version>17_r2</version>
   <scope>provided</scope>
 </dependency>
 ```


### PR DESCRIPTION
As far as I see the current version of maps is 17_r2. 17_r1 can't be found
