### PR TITLE
Disabled analytics-v1 module

### DIFF
--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -73,7 +73,7 @@
                 <module>compatibility-v4</module>
                 <module>compatibility-v7-gridlayout</module>
                 <module>compatibility-v13</module>
-                <module>analytics-v1</module>
+                <!--<module>analytics-v1</module>-->
                 <module>analytics-v2</module>
                 <module>admob</module>
                 <module>gcm</module>


### PR DESCRIPTION
The old analytics SDK is no longer available in SDK manager, so the
folder for it is not created if the Android SDK was installed recently.
This is causing the deployer to fail upon reaching analytics-v1.
Disabled the module to prevent failure, but left the line commented out
in case it is needed for legacy purposes.
