### PR TITLE
Specify Android SDK Platform in plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <properties>
         <!-- absolute path to the Android SDK install as defined in the ANDROID_HOME environment variable -->
         <android.sdk.path>${env.ANDROID_HOME}/</android.sdk.path>
+        <android.sdk.platform>17</android.sdk.platform>
 
         <!-- The repository server for your android artifacts (e.g. Nexus instance in this example)-->
         <repo.id>android.repo</repo.id>
@@ -104,6 +105,11 @@
                     <groupId>com.jayway.maven.plugins.android.generation2</groupId>
 		    <artifactId>android-maven-plugin</artifactId>
                     <version>3.5.4-SNAPSHOT</version>
+                    <configuration>
+                        <sdk>
+                            <platform>${android.sdk.platform}</platform>
+                        </sdk>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Fixes the following deployment error:

```
[ERROR] Failed to execute goal com.jayway.maven.plugins.android.generation2:android-maven-plugin:3.5.4-SNAPSHOT:generate-sources (default-generate-sources) on project compatibility-v7-gridlayout: Execution default-generate-sources of goal com.jayway.maven.plugins.android.generation2:android-maven-plugin:3.5.4-SNAPSHOT:generate-sources failed:  No Android Platform Version/API Level has been configured.  Add e.g. <sdk><platform>17</platform></sdk> to the plugin configuration. -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal com.jayway.maven.plugins.android.generation2:android-maven-plugin:3.5.4-SNAPSHOT:generate-sources (default-generate-sources) on project compatibility-v7-gridlayout: Execution default-generate-sources of goal com.jayway.maven.plugins.android.generation2:android-maven-plugin:3.5.4-SNAPSHOT:generate-sources failed:  No Android Platform Version/API Level has been configured.  Add e.g. <sdk><platform>17</platform></sdk> to the plugin configuration.
at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:225)
at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:84)
at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:59)
at org.apache.maven.lifecycle.internal.LifecycleStarter.singleThreadedBuild(LifecycleStarter.java:183)
at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:161)
at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:319)
at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:156)
at org.apache.maven.cli.MavenCli.execute(MavenCli.java:537)
at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:196)
at org.apache.maven.cli.MavenCli.main(MavenCli.java:141)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
at java.lang.reflect.Method.invoke(Method.java:597)
at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:290)
at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:230)
at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:409)
at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:352)
Caused by: org.apache.maven.plugin.PluginExecutionException: Execution default-generate-sources of goal com.jayway.maven.plugins.android.generation2:android-maven-plugin:3.5.4-SNAPSHOT:generate-sources failed:  No Android Platform Version/API Level has been configured.  Add e.g. <sdk><platform>17</platform></sdk> to the plugin configuration.
at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:110)
at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:209)
... 19 more
Caused by: com.jayway.maven.plugins.android.InvalidConfigurationException:  No Android Platform Version/API Level has been configured.  Add e.g. <sdk><platform>17</platform></sdk> to the plugin configuration.
at com.jayway.maven.plugins.android.AndroidSdk.<init>(AndroidSdk.java:85)
at com.jayway.maven.plugins.android.AbstractAndroidMojo.getAndroidSdk(AbstractAndroidMojo.java:1150)
at com.jayway.maven.plugins.android.phase01generatesources.GenerateSourcesMojo.generateR(GenerateSourcesMojo.java:459)
at com.jayway.maven.plugins.android.phase01generatesources.GenerateSourcesMojo.execute(GenerateSourcesMojo.java:193)
at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:101)
... 20 more
```
