### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -178,7 +178,7 @@ For the core platforms
 <dependency>
   <groupId>android</groupId>
   <artifactId>android</artifactId>
-  <version>4.2_r1</version>
+  <version>4.2.2_r2</version>
   <scope>provided</scope>
 </dependency>
 ```


### PR DESCRIPTION
In my machine I got installed following packages:

`cat  ~/.m2/repository/android/android/maven-metadata-local.xml`

```
<?xml version="1.0" encoding="UTF-8"?>
<metadata>
  <groupId>android</groupId>
  <artifactId>android</artifactId>
  <versioning>
    <release>4.2.2_r2</release>
    <versions>
      <version>1.5_r4</version>
      <version>1.6_r3</version>
      <version>2.1_r3</version>
      <version>2.2_r3</version>
      <version>2.3.3_r2</version>
      <version>3.0_r2</version>
      <version>3.1_r3</version>
      <version>3.2_r1</version>
      <version>4.0_r3</version>
      <version>4.0.3_r3</version>
      <version>4.1.2_r4</version>
      <version>4.2.2_r2</version>
    </versions>
    <lastUpdated>20130618152101</lastUpdated>
  </versioning>
</metadata>
```

So I'd recommend to use `4.2.2_r2` instead of `4.2_r2`
