### PR TITLE
Fixed deploy configuration for v7 appcompat library.

### DIFF
--- a/extras/compatibility-v7-appcompat/pom.xml
+++ b/extras/compatibility-v7-appcompat/pom.xml
@@ -108,7 +108,7 @@
                             <packaging>jar</packaging>
                             <version>${jar.version}</version>
                             <file>${jar.path}</file>
-	                        <sources>${project.build.directory}/support-sources.jar</sources>
+	                        <sources>${project.build.directory}/support-appcompat-sources.jar</sources>
                             <url>${repo.url}</url>
                             <repositoryId>${repo.id}</repositoryId>
                         </configuration>


### PR DESCRIPTION
There was an error in the configuration of maven-deploy-plugin for v7 appcompat library. Sources JAR file was incorrectly named.
