### PR TITLE
OSX 10.8 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,8 +148,8 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>[3.1.1,)</version>
-                  <message>Check for Maven version &gt;=3.1.1 failed. Upgrade your Maven installation.</message>
+                  <version>[3.0.3,)</version>
+                  <message>Check for Maven version &gt;=3.0.3 failed. Upgrade your Maven installation.</message>
                 </requireMavenVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
OSX have Maven 3.0.3 included, I successfully build project with it, so there is no requirement in 3.1.1
