### PR TITLE
fixed artifact version names in dependenies on appcompat and play-licensing

### DIFF
--- a/extras/compatibility-v7-mediarouter/pom.xml
+++ b/extras/compatibility-v7-mediarouter/pom.xml
@@ -33,13 +33,13 @@
 		<dependency>
 			<groupId>${extras.compatibility.v7.appcompat.groupid}</groupId>
 			<artifactId>${extras.compatibility.v7.appcompat.artifactid}</artifactId>
-			<version>19.0.0</version>
+			<version>19</version>
 			<type>apklib</type>
 		</dependency>
 		<dependency>
 			<groupId>${extras.compatibility.v7.appcompat.groupid}</groupId>
 			<artifactId>${extras.compatibility.v7.appcompat.artifactid}</artifactId>
-			<version>19.0.0</version>
+			<version>19</version>
 			<type>jar</type>
 		</dependency>
     </dependencies>

--- a/extras/play-apk-expansion/downloader-library/pom.xml
+++ b/extras/play-apk-expansion/downloader-library/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.google.android.licensing</groupId>
             <artifactId>play-licensing</artifactId>
-            <version>2.0.0</version>
+            <version>2</version>
             <type>apklib</type>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Small fix for the issue with compatibility-v7-appcompat and the play-licensing artifacts versions. 
The issue was that there were no jars and apklibs in the local repository in the "19.0.0" and "2.0.0" folders respectively. But they were in the folders "19" and "2". That's why modules, who had the dependencies on these two artifacts couldn't be built: the compatibility_v7_mediarouter and play-apk-expansion-downloader. 
So I've changed the dependencies versions to 19 and 2. After that the project compiled smoothly. 

OS: Linux Mint 16
Maven version: 3.1.1 
JDK: 1.7.0_45
