### PR TITLE
Fixed add-ons folder name pattern.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -73,7 +73,7 @@ names like android-3, android-4 and so on.
 name reinstall that platform from the android tool.
 
 - In a similar manner the folder names in add-ons have to use the
-pattern addon_google_apis_google-3 up to addon_google_apis_google-15.
+pattern addon-google_apis-google-3 up to addon-google_apis-google-15.
 
 - If the folder names are different reinstall the add-ons as well
 


### PR DESCRIPTION
I just installed the SDK, and it uses the naming pattern `addon-google_apis_google-[1-9][0-9]*`. I updated the README to use that pattern.
