### PR TITLE
A workaround of 'file not found` on admob and gcm

### DIFF
--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -77,8 +77,6 @@
                 <module>compatibility-v13</module>
                 <!--<module>analytics-v1</module>-->
                 <module>analytics-v2</module>
-                <module>admob</module>
-                <module>gcm</module>
                 <module>google-play-services</module>
                 <module>google-play-services-for-froyo</module>
                 <module>play-licensing</module>


### PR DESCRIPTION
When I run `mvn install` with android studio environment (after completing `android update sdk -u`), I get the following errors:

```
$ mvn install
... (snip) ...
[ERROR] Failed to execute goal org.codehaus.mojo:properties-maven-plugin:1.0-alpha-2:read-project-properties (default) on project admob: Properties file not found: /usr/local/android-studio/sdk/extras/google/admob_ads_sdk/source.properties -> [Help 1]
```

```
$ mvn install
... (snip) ...
[ERROR] Failed to execute goal org.codehaus.mojo:properties-maven-plugin:1.0-alpha-2:read-project-properties (default) on project gcm-client: Properties file not found: /usr/local/android-studio/sdk/extras/google/gcm/source.properties -> [Help 1]
```

And the directories `admob_ads_sdk/` and `gcm/` are missing in the sdk directory:

```
$ ls -alF /usr/local/android-studio/sdk/extras/google 
total 40
drwxrwxr-x 10 ikuo 4096 Feb  8 12:16 ./
drwxrwxr-x  4 ikuo 4096 Feb  8 12:16 ../
drwxrwxr-x  2 ikuo 4096 Feb  8 12:16 analytics_sdk_v2/
drwxrwxr-x  5 ikuo 4096 Feb  8 12:16 google_play_services/
drwxrwxr-x  5 ikuo 4096 Feb  8 12:16 google_play_services_froyo/
drwxrwxr-x  3 ikuo 4096 Feb  8 12:16 m2repository/
drwxrwxr-x  5 ikuo 4096 Feb  8 12:16 play_apk_expansion/
drwxrwxr-x  3 ikuo 4096 Feb  8 12:16 play_billing/
drwxrwxr-x  5 ikuo 4096 Feb  8 12:16 play_licensing/
drwxrwxr-x  4 ikuo 4096 Feb  8 12:16 webdriver/
```

Although I'm not sure that it is the right solution, `mvn install` succeeded against the rest of android library after making changes of this pull-request.
