### PR TITLE
Workaround for #197, informative error message for not supporting JDK 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,10 @@
                   <version>[3.1.1,)</version>
                   <message>Check for Maven version &gt;=3.1.1 failed. Upgrade your Maven installation.</message>
                 </requireMavenVersion>
+                <requireJavaVersion>
+                  <version>(,1.7]</version>
+                  <message>Java 8 is not yet supported.</message>
+                </requireJavaVersion>
               </rules>
             </configuration>
           </execution>


### PR DESCRIPTION
Uses maven enforcer rule to notify user that JDK 8 is not yet supported (See #197)
