### PR TITLE
compatibility-v7-gridlayout used incorrect artifact id

### DIFF
--- a/extras/compatibility-v7-gridlayout/pom.xml
+++ b/extras/compatibility-v7-gridlayout/pom.xml
@@ -99,7 +99,7 @@
                         <goals><goal>deploy-file</goal></goals>
                         <configuration>
                             <groupId>${extras.compatibility.v7.groupid}</groupId>
-                            <artifactId>${extras.compatibility.v7.artifactid}</artifactId>
+                            <artifactId>${android.support.artifactid}</artifactId>
                             <packaging>jar</packaging>
                             <version>${jar.version}</version>
                             <file>${jar.path}</file>
@@ -114,7 +114,7 @@
                         <goals><goal>deploy-file</goal></goals>
                         <configuration>
                             <groupId>${extras.compatibility.v7.groupid}</groupId>
-                            <artifactId>${extras.compatibility.v7.artifactid}</artifactId>
+                            <artifactId>${android.support.artifactid}</artifactId>
                             <packaging>apklib</packaging>
                             <version>${jar.version}</version>
                             <file>target/${android.support.artifactid}-${project.version}.apklib</file>


### PR DESCRIPTION
it used "compatibility-v7" instead of "compatibility-v7-gridlayout" as artifact id
