### PR TITLE
extras admob-ads-sdk: remove module

### DIFF
--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -83,9 +83,10 @@
                 <module>compatibility-v13</module>
 				<!--  deprecated by Google, will leave in for a while in case someone wants to manually activate and use it -->
                 <!-- <module>analytics-v2</module> -->
-                <!--  deprecated by Google with Aug 2014, but still available for download
-                might remove then, see http://googleadsdeveloper.blogspot.ca/2014/02/since-joining-google-play-services-back.html  -->
-                <module>admob-ads-sdk</module>
+                <!--  deprecated by Google with Aug 2014, no longer available in the SDK manager.
+                Will leave in for a while in case someone wants to manually activate and use it.
+                see http://googleadsdeveloper.blogspot.ca/2014/02/since-joining-google-play-services-back.html  -->
+                <!-- <module>admob-ads-sdk</module> -->
                 <!--  deprecated by Google, will leave in for a while in case someone wants to manually activate and use it -->
                 <!-- <module>gcm</module>  -->
                 <module>google-play-services</module>


### PR DESCRIPTION
The standalone AdMob SDK seems to be removed from the SDK manager r23. 
