### PR TITLE
Use the correct source.properties directory for the google-gdk-19 module

### DIFF
--- a/add-ons/google-gdk-19/pom.xml
+++ b/add-ons/google-gdk-19/pom.xml
@@ -58,6 +58,19 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>properties-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>read-project-properties</goal>
+                        </goals>
+                        <configuration>
+                            <files>
+                                <file>${sdk.addons.path}/${gdk.directory}/source.properties</file>
+                            </files>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
This commit overrides the parent pom's properties-maven-plugin
configuration in order to specify the gdk.directory as the correct path
to the source.properties file.

fixes #248
