### PR TITLE
Fix broken webdav extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,12 +133,12 @@
       <extension>
         <groupId>org.apache.maven.wagon</groupId>
         <artifactId>wagon-webdav-jackrabbit</artifactId>
-        <version>2.5</version>
+        <version>2.7</version>
       </extension>
       <extension>
         <groupId>org.apache.maven.wagon</groupId>
         <artifactId>wagon-file</artifactId>
-        <version>2.5</version>
+        <version>2.7</version>
       </extension>
     </extensions>
     <plugins>


### PR DESCRIPTION
Fixes issue #264 
I had this error when trying to deploy on my repo : 

```
[WARNING] Error injecting: org.apache.maven.wagon.providers.webdav.WebDavWagon
com.google.inject.ProvisionException: Guice provision errors:

1) Error injecting constructor, java.lang.NoClassDefFoundError: org/apache/commons/logging/LogFactory
  at org.apache.maven.wagon.providers.webdav.WebDavWagon.<init>(Unknown Source)
  while locating org.apache.maven.wagon.providers.webdav.WebDavWagon
```

``` diff
diff --git a/pom.xml b/pom.xml
index ac9e561..8633d6c 100644
--- a/pom.xml
+++ b/pom.xml
@@ -133,12 +133,12 @@
       <extension>
         <groupId>org.apache.maven.wagon</groupId>
         <artifactId>wagon-webdav-jackrabbit</artifactId>
-        <version>2.5</version>
+        <version>2.7</version>
       </extension>
       <extension>
         <groupId>org.apache.maven.wagon</groupId>
         <artifactId>wagon-file</artifactId>
-        <version>2.5</version>
+        <version>2.7</version>
       </extension>
     </extensions>
     <plugins>
```
