### PR TITLE
need newest parent version, as others not found

### DIFF
--- a/extras/gcm/gcm-client/pom.xml
+++ b/extras/gcm/gcm-client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.simpligility.android.sdk-deployer</groupId>
         <artifactId>android-gcm</artifactId>
-        <version>2.4.0</version>
+        <version>2.7.0</version>
     </parent>
 
     <properties>

--- a/extras/gcm/gcm-server/pom.xml
+++ b/extras/gcm/gcm-server/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.simpligility.android.sdk-deployer</groupId>
         <artifactId>android-gcm</artifactId>
-        <version>2.4.0</version>
+        <version>2.7.0</version>
     </parent>
 
     <properties>

--- a/extras/gcm/pom.xml
+++ b/extras/gcm/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.simpligility.android.sdk-deployer</groupId>
         <artifactId>android-extras</artifactId>
-        <version>2.4.0</version>
+        <version>2.7.0</version>
     </parent>
     <profiles>
         <profile>


### PR DESCRIPTION
after manually uncommenting gcm in the extras/pom.xml the build would fails as it couldn't find the 2.4.0 parent. Changing it to 2.7.0 means I can run mvn install in the maven-android-sdk-deployer/extras/gcm folder
