### PR TITLE
Remove deprecated platforms, add-ons, and extras

### DIFF
--- a/add-ons/pom.xml
+++ b/add-ons/pom.xml
@@ -52,15 +52,8 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <modules>
-                <module>google-apis-3</module>
-                <module>google-apis-4</module>
-                <module>google-apis-7</module>
                 <module>google-apis-8</module>
                 <module>google-apis-10</module>
-                <module>google-apis-11</module>
-                <module>google-apis-12</module>
-                <module>google-apis-13</module>
-                <module>google-apis-14</module>
                 <module>google-apis-15</module>
                 <module>google-apis-16</module>
                 <module>google-apis-17</module>

--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -89,7 +89,6 @@
                 <!--  deprecated by Google, will leave in for a while in case someone wants to manually activate and use it -->
                 <!-- <module>gcm</module>  -->
                 <module>google-play-services</module>
-                <module>google-play-services-froyo</module>
                 <module>play-licensing</module>
                 <module>play-apk-expansion</module>
 				<module>multidex</module>

--- a/platforms/pom.xml
+++ b/platforms/pom.xml
@@ -51,23 +51,16 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <modules>
-                <module>android-3</module>
-                <module>android-4</module>
-                <module>android-7</module>
                 <module>android-8</module>
                 <module>android-10</module>
-                <module>android-11</module>
-                <module>android-12</module>
-                <module>android-13</module>
-                <module>android-14</module>
                 <module>android-15</module>
                 <module>android-16</module>
-				<module>android-17</module>
-				<module>android-18</module>
-				<module>android-19</module>
-				<module>android-20</module>
-				<module>android-21</module>
-				<module>android-22</module>
+		<module>android-17</module>
+		<module>android-18</module>
+		<module>android-19</module>
+		<module>android-20</module>
+		<module>android-21</module>
+		<module>android-22</module>
             </modules>
         </profile>
         <profile>


### PR DESCRIPTION
The Android SDK manager no longer supports platforms other than 9, 10, 15, 16, 17, 18, 19, 20, 21, and 22. Add-ons from these platforms are also not present, nor is the froyo play store extra.

![](http://i.imgur.com/vBoY9UA.png)
![](http://imgur.com/LJTT9r8.png)

This PR removes these deprecated profiles from each respective `all` profile, so that someone who has "all" the available libraries won't get an error when they run `mvn install`.