### PR TITLE
Fix path Play Licensing and APK expansion

### DIFF
--- a/extras/play-apk-expansion/pom.xml
+++ b/extras/play-apk-expansion/pom.xml
@@ -25,7 +25,7 @@
                         </goals>
                         <configuration>
                             <files>
-                                <file>${sdk.extras.path}/google/play_apk_expansion/source.properties</file>
+                                <file>${sdk.extras.path}/google/market_apk_expansion/source.properties</file>
                             </files>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
     <sdk.extras.gcm.path>${sdk.extras.path}/google/gcm</sdk.extras.gcm.path>
     <sdk.extras.google.play.services.path>${sdk.extras.path}/google/google_play_services</sdk.extras.google.play.services.path>
     <sdk.extras.google.play.services.for.froyo.path>${sdk.extras.path}/google/google_play_services_froyo</sdk.extras.google.play.services.for.froyo.path>
-    <sdk.extras.google.play.apk.expansion.path>${sdk.extras.path}/google/play_apk_expansion</sdk.extras.google.play.apk.expansion.path>
-    <sdk.extras.google.play.licensing.path>${sdk.extras.path}/google/play_licensing</sdk.extras.google.play.licensing.path>
+    <sdk.extras.google.play.apk.expansion.path>${sdk.extras.path}/google/market_apk_expansion</sdk.extras.google.play.apk.expansion.path>
+    <sdk.extras.google.play.licensing.path>${sdk.extras.path}/google/market_licensing</sdk.extras.google.play.licensing.path>
     <sdk.tools.path>${android.sdk.path}/tools</sdk.tools.path>
     <sdk.tools.annotations.path>${android.sdk.path}/tools/support</sdk.tools.annotations.path>
     <platform.android.groupid>android</platform.android.groupid>


### PR DESCRIPTION
Google Play APK Expansion Library and Google Play Licensing Library were installed to different destination. Try to remove this libraries using Android SDK Manager and install them again, then check their destination whether it is extras/google/play_* or extras/google/market_*

P.S: I used Android SDK Manager 25.1.3.