### PR TITLE
commenting out play services extras as it seems to be deprecated

### DIFF
--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -89,7 +89,7 @@
                 <!--  <module>admob-ads-sdk</module> -->
                 <!--  deprecated by Google, will leave in for a while in case someone wants to manually activate and use it -->
                 <!-- <module>gcm</module>  -->
-                <module>google-play-services</module>
+                <!--<module>google-play-services</module>-->
                 <module>play-licensing</module>
                 <module>play-apk-expansion</module>
                 <module>multidex</module>


### PR DESCRIPTION
This will resolve #293  and #291.

Basically, google removed the gigantic play services library from the SDK and only has the modules in the m2repository now.

See http://stackoverflow.com/questions/37310684/missing-sdk-extras-google-google-play-services-libproject-folder-after-updat